### PR TITLE
Fixed Spotify cover art

### DIFF
--- a/Websites/Spotify.js
+++ b/Websites/Spotify.js
@@ -61,7 +61,7 @@ function setup()
 	};
 	spotifyInfoHandler.cover = function()
 	{
-		var currCover = document.getElementsByClassName("cover-art-image cover-art-image-loaded")[document.getElementsByClassName("cover-art-image cover-art-image-loaded").length - 1].style.backgroundImage;
+		var currCover = document.getElementsByClassName("cover-art-image")[document.getElementsByClassName("cover-art-image").length - 1].style.backgroundImage;
 		return currCover.substring(currCover.indexOf("(") + 2, currCover.indexOf(")") - 1);
 	};
 	spotifyInfoHandler.durationString = function()


### PR DESCRIPTION
The cover-art-image-loaded doesn't seem to exist anymore so the search didn't return anything. Only searching for cover-art-image fixes this