### PR TITLE
Add Bandcamp support

### DIFF
--- a/Websites/Bandcamp.js
+++ b/Websites/Bandcamp.js
@@ -1,0 +1,71 @@
+// Adds support for Bandcamp
+/*global init createNewMusicInfo createNewMusicEventHandler convertTimeToString capitalize*/
+
+function setup()
+{
+	var bandcampInfoHandler = createNewMusicInfo();
+
+	bandcampInfoHandler.player = function()
+	{
+		return "Bandcamp";
+	};
+
+	bandcampInfoHandler.readyCheck = function()
+	{
+		return !!document.querySelector('#trackInfoInner');
+	};
+
+	bandcampInfoHandler.state = function()
+	{
+		return document.querySelector('#trackInfoInner .playbutton').className.includes('playing') ? 1 : 2;
+	};
+	bandcampInfoHandler.title = function()
+	{
+		return document.querySelector('#trackInfoInner .track_info .title').innerText;
+	};
+	bandcampInfoHandler.artist = function()
+	{
+		return document.querySelector('#name-section [itemprop="byArtist"] > a').innerText;
+	};
+	bandcampInfoHandler.album = function()
+	{
+		return document.querySelector('#name-section .trackTitle').innerText;
+	};
+	bandcampInfoHandler.cover = function()
+	{
+		return document.querySelector('#tralbumArt .popupImage > img').src.replace('_16', '_0');
+	};
+	bandcampInfoHandler.duration = function()
+	{
+		return document.querySelector('audio[src]').duration;
+	};
+	bandcampInfoHandler.position = function()
+	{
+		return document.querySelector('audio[src]').currentTime;
+	};
+
+	var bandcampEventHandler = createNewMusicEventHandler();
+
+	bandcampEventHandler.readyCheck = bandcampInfoHandler.readyCheck;
+
+	bandcampEventHandler.playpause = function()
+	{
+        document.querySelector('#trackInfoInner .playbutton').click();
+	};
+	bandcampEventHandler.next = function()
+	{
+		document.querySelector('#trackInfoInner .nextbutton').click();
+	};
+	bandcampEventHandler.previous = function()
+	{
+		document.querySelector('#trackInfoInner .prevbutton').click();
+	};
+	bandcampEventHandler.progressSeconds = function(position)
+	{
+		return document.querySelector('audio[src]').currentTime = position;
+	};
+}
+
+
+setup();
+init();

--- a/manifest.json
+++ b/manifest.json
@@ -152,6 +152,16 @@
     ]
   },
   {
+    "matches":        ["*://*/*"],
+    "include_globs": [
+      "*://*.bandcamp.com/album/*"
+    ],
+    "js": [
+      "WebNowPlaying.js",
+      "Websites/Bandcamp.js"
+    ]
+  },
+  {
     "matches": [
       "<all_urls>"
     ],
@@ -167,7 +177,8 @@
       "*://open.spotify.*/*",
       "*://www.deezer.*/*",
       "*://play.pocketcasts.*/*",
-      "*://app.plex.tv/*"
+      "*://app.plex.tv/*",
+      "*://*.bandcamp.com/album/*"
     ],
     "js": [
       "WebNowPlaying.js",


### PR DESCRIPTION
Only works on artists not using a custom domain.
<https://radicaldreamland.bandcamp.com/> works, <https://music.disasterpeace.com/> doesn't.
Can probably get around this by checking every single page if it's from Bandcamp. But I'm not familiar enough with the extension to make sure it's done properly.

There also may be problems with covers not showing up.

Supports:

- Title
- Artist
- Album
- Cover
- Duration
- Position
- Progress
- PlayPause, Next, Prev
- Volume
- State
- Status