### PR TITLE
Updated a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Now Playing Companion Extension
 The extension to go along with the WebNowPlaying plugin for Rainmeter  
-Source code and downloads for the Rainmeter plugin can be found [here](https://github.com/tjhrulz/WebNowPlaying-BrowserExtension)  
+Source code and downloads for the Rainmeter plugin can be found [here](https://github.com/tjhrulz/WebNowPlaying)  
   
 The extension can be found in both the [Chrome Web Store](https://chrome.google.com/webstore/detail/webnowplaying-companion/jfakgfcdgpghbbefmdfjkbdlibjgnbli) and the [Firefox Addons Store](https://addons.mozilla.org/en-US/firefox/addon/webnowplaying-companion/).  
 Other browsers will be supported as requested. Please feel free to report any bugs are found when using these, even on 'unsupported' browsers that can use Chrome/Firefox extensions.


### PR DESCRIPTION
Link probably should point to https://github.com/tjhrulz/WebNowPlaying but pointed to https://github.com/tjhrulz/WebNowPlaying-BrowserExtension instead...
(not major, just annoying me a little...)