### PR TITLE
Fix to show "HD" Album art.

### DIFF
--- a/Websites/Spotify.js
+++ b/Websites/Spotify.js
@@ -42,17 +42,12 @@ function setup()
 	spotifyInfoHandler.album = null;
 	spotifyInfoHandler.cover = function()
 	{
-		//If album art is blank update it
-		if(lastKnownAlbumArt === "")
+		// Update Album art for "HD" version...
+		if(lastKnownAlbumArt == "" || document.getElementsByClassName("cover-art").length == 3)
 		{
-			lastKnownAlbumArt = document.getElementsByClassName("cover-art")[0].children[0].children[1].src;
+			lastKnownAlbumArt = document.getElementsByClassName("cover-art")[0].children[0].children[1].src.replace('ab67616d00004851', 'ab67616d00001e02');
 		}
-		//If album art is not blank and we have 3 album art then it must be the big version on display so update to current album art
-		else if(document.getElementsByClassName("cover-art").length === 3)
-		{
-			lastKnownAlbumArt = document.getElementsByClassName("cover-art")[0].children[0].children[1].src;
-		}
-		//If it was not blnak and we have less than 3 album art then it is already set to the small album art or it is set to the big album art and the big album art is not visible
+		//If it was not blank and we have less than 3 album art then it is already set to the small album art or it is set to the big album art and the big album art is not visible
 		return lastKnownAlbumArt;
 	};
 	spotifyInfoHandler.durationString = function()


### PR DESCRIPTION
Regarding: https://github.com/tjhrulz/WebNowPlaying-BrowserExtension/issues/26
This seems to say it might already be resolved but not for me...: https://github.com/tjhrulz/WebNowPlaying-BrowserExtension/issues/74
I monitored the network log when loading low and high res art work, and they seem the same, except the first few characters:
`ab67616d00004851`... (64x64) vs `ab67616d00001e02`... ("HD")
I tried replacing the art's `src` attribute to match the "HD" version every time, and it seems to work for me. 